### PR TITLE
gcc 10 compilation warnings.

### DIFF
--- a/src/game/clearpath.c
+++ b/src/game/clearpath.c
@@ -341,11 +341,12 @@ static vec2_t compute_vnew(const vec_vec2_t *outside_points, vec2_t des_v, vec2_
 {
     float min_dist = INFINITY, len;
     vec2_t ret;
+    memset( &ret, 0, sizeof( vec2_t ) );
 
     for(int i = 0; i < vec_size(outside_points); i++) {
 
         /* The points are in worldspace coordinates. Convert them to the entity's 
-         * local space to get the adimissible velocities. */
+         * local space to get the admissible velocities. */
         vec2_t curr = vec_AT(outside_points, i), diff;
         PFM_Vec2_Sub(&curr, &ent_xz_pos, &curr);
 

--- a/src/lib/public/nuklear.h
+++ b/src/lib/public/nuklear.h
@@ -23753,7 +23753,6 @@ nk_do_property(nk_flags *ws,
         dst = buffer;
     } else {
         switch (variant->kind) {
-        default: break;
         case NK_PROPERTY_INT:
             nk_itoa(string, variant->value.i);
             num_len = nk_strlen(string);
@@ -23765,6 +23764,9 @@ nk_do_property(nk_flags *ws,
         case NK_PROPERTY_DOUBLE:
             NK_DTOA(string, variant->value.d);
             num_len = nk_string_float_limit(string, NK_MAX_FLOAT_PRECISION);
+            break;
+        default:
+            num_len = 0;
             break;
         }
         size = font->width(font->userdata, font->height, string, num_len);

--- a/src/render/gl_state.h
+++ b/src/render/gl_state.h
@@ -105,7 +105,7 @@ enum utype{
     UTYPE_MAT4_ARR,
     UTYPE_COMPOSITE,
     UTYPE_ARRAY,
-}type;
+};
 
 struct mdesc{
     const char *name;


### PR DESCRIPTION
patch fixs compilation warnings about uninitialized variables threated as errors.

Fixes #19 